### PR TITLE
Fix typos, formatting, and links

### DIFF
--- a/lab_manual/lab1/index.md
+++ b/lab_manual/lab1/index.md
@@ -37,7 +37,7 @@ If you are unfamiliar with a particular MATLAB function, type `doc <function>`  
 
 Since these exercises are intended to teach the basics of MATLAB, some possible solutions are provided.
 
-1.  Create a vector `t` representing the time variable with range of one second and sampling period of of $T_s = 0.001$ sec. One way to create a vector of evenly spaced numbers in MATLAB is with the `:` operator. Alternatively, you can use the `linspace` function.
+1.  Create a vector `t` representing the time variable with range of one second and sampling period of $T_s = 0.001$ sec. One way to create a vector of evenly spaced numbers in MATLAB is with the `:` operator. Alternatively, you can use the `linspace` function.
 
     *Solution 1:* 
     ```
@@ -55,7 +55,7 @@ Since these exercises are intended to teach the basics of MATLAB, some possible 
     xt = sin(2*pi*t);
     plot(t,xt);
     ```
-    *Explanation:* Many MATLAB functions that operate on scalars (including `sin`) are automatically ['mapped'][4] to arrays. Since `t` is an vector, the expression `sin(2*pi*t)` applies the scalar function $x(t) = sin( 2\pi t)$ to each element of `t`.
+    *Explanation:* Many MATLAB functions that operate on scalars (including `sin`) are automatically ['mapped'][4] to arrays. Since `t` is a vector, the expression `sin(2*pi*t)` applies the scalar function $x(t) = sin( 2\pi t)$ to each element of `t`.
     
     *Solution 2:*
     ```
@@ -116,7 +116,7 @@ Since these exercises are intended to teach the basics of MATLAB, some possible 
     
 ### Using the STM32H735G discovery kit and starter code
 
-In order for you to get started programming the board, we have created a sample project which passes a signal from the input jack to the output jack (this is known as a talkthrough.) Additionally, the spectrum of the input signal is visualized on the LCD.
+In order for you to get started programming the board, we have created a sample project which passes a signal from the input jack to the output jack. This is known as a talkthrough. Additionally, the spectrum of the input signal is visualized on the LCD.
 
 1. Follow the [instructions in the setup guide][5] to import the starter code and program the board..
 

--- a/lab_manual/lab2/index.md
+++ b/lab_manual/lab2/index.md
@@ -2,9 +2,7 @@
 
 ## Aim of the experiment
 
-The aim of this experiment is to
-
-* explore the design tradeoffs in signal quality vs. runtime complexity in computing amplitude values of sinusoidal signals.
+The aim of this experiment is to explore the design tradeoffs in signal quality vs. runtime complexity in computing amplitude values of sinusoidal signals.
 
 Sinusoidal waveforms will be computed in discrete time, plotted, and played as audio signals.
 

--- a/lab_manual/primer.md
+++ b/lab_manual/primer.md
@@ -86,6 +86,6 @@ We will also use MATLAB throughout the course. Please see the [instructions for 
 [9]:https://en.wikipedia.org/wiki/SIMD
 [10]:https://en.wikipedia.org/wiki/Quadrature_amplitude_modulation
 [11]:https://en.wikipedia.org/wiki/Modem
-[12]:https://en.wikipedia.org/wiki/Numerical_error
+[12]:https://en.wikipedia.org/wiki/Floating-point_arithmetic#Accuracy_problems
 [13]:https://www.st.com/resource/en/user_manual/dm00682073-discovery-kit-with-stm32h735ig-mcu-stmicroelectronics.pdf
 [14]:http://users.ece.utexas.edu/~bevans/courses/realtime/homework/matlab.html

--- a/lab_manual/setup.md
+++ b/lab_manual/setup.md
@@ -37,7 +37,7 @@ The lab room (EER 1.810) has 12 stations, each with a signal generator (top) and
 
 Connect the hardware using the following configuration:
 
-1. Connect the discovery kit to you computer using the attached USB cable.
+1. Connect the discovery kit to your computer using the attached USB cable.
 2. Attach one cable from signal generator output to the blue line in on the discovery board.
 3. Attach the second cable from the oscilloscope input to the green line out on the discovery board.
 

--- a/lab_manual/stm32h735g.md
+++ b/lab_manual/stm32h735g.md
@@ -25,10 +25,10 @@ We have provided a project that contains all of the starter code necessary to co
 If you do not already have a working installation of MATLAB, follow the [instructions on the course webpage][2].
 
 1. Download the [zip file containing the starter code][3] and [setup script][4] and extract the contents to a convenient location.
-2. In MATLAB, and navigate to the folder you just extracted. You can either use the 'Current Folder' menu in the MATLAB GUI or change directory with ```cd <downloads>/445S_lab_files'.
+2. In MATLAB, and navigate to the folder you just extracted. You can either use the 'Current Folder' menu in the MATLAB GUI or change directory with ```cd <downloads>/445S_lab_files```.
 3. Run the lab_setup.m script by typing ```lab_setup``` in the command window or by opening the file in the MATLAB editor and clicking the run icon (F5).
 4. Follow the on-screen instructions to create a new project. Make sure to choose a name for your project that does not conflict with an existing project in your workspace.
-5. Open the STM32CubeIDE and import the extracted project by clicking File -> Import. Under the 'General' category, choose 'existing projects into workspace.' Select the folder you just extracted as the root directory and click finish.
+5. Open the STM32CubeIDE and import the extracted project by clicking File → Import. Under the 'General' category, choose 'existing projects into workspace.' Select the folder you just extracted as the root directory and click finish.
 
 ## Running the project on the discovery board
 


### PR DESCRIPTION
I think [floating point accuracy problems](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Accuracy_problems) is a more concrete set of examples of the numerical errors introduced by floating point arithmetic than the article on [numerical error](https://en.wikipedia.org/wiki/Numerical_error)

The other changes are just minor typos and formatting inconsistencies that I found while reading